### PR TITLE
Add signal strategies and TP backtester utility

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -1,0 +1,169 @@
+"""Backtesting utilities for fixed take-profit strategies."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import pandas as pd
+
+
+REQUIRED_COLUMNS = {"Open", "High", "Low", "Close", "Volume"}
+TRADE_CAPITAL = 10_000.0
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+def _validate_dataframe(df: pd.DataFrame, required: Iterable[str]) -> None:
+    missing = [column for column in required if column not in df.columns]
+    if missing:
+        raise ValueError(
+            "DataFrame is missing required columns: " + ", ".join(sorted(missing))
+        )
+
+
+def _ensure_boolean_series(entries: pd.Series, index: pd.Index) -> pd.Series:
+    if not isinstance(entries, pd.Series):
+        raise TypeError("entries must be a pandas Series")
+    if len(entries) != len(index):
+        raise ValueError("entries Series must align with the DataFrame index")
+    return entries.reindex(index).fillna(False).astype(bool)
+
+
+def _calculate_fee(amount: float) -> float:
+    if amount <= 0:
+        return 0.0
+    if amount <= 1_000:
+        return 5.0
+    if amount <= 3_000:
+        return 10.0
+    if amount <= 10_000:
+        return 19.95
+    if amount <= 25_000:
+        return 29.95
+    return amount * 0.0012
+
+
+def _sanitize_name(name: str) -> str:
+    safe_chars = [c if c.isalnum() or c in {"-", "_"} else "_" for c in name.strip()]
+    sanitized = "".join(safe_chars) or "strategy"
+    return sanitized
+
+
+def run_tp_backtest(
+    df: pd.DataFrame, entries: pd.Series, tp_pct: float, name: str = "strategy"
+) -> Tuple[pd.DataFrame, dict]:
+    """Run a take-profit backtest.
+
+    Parameters
+    ----------
+    df:
+        OHLCV DataFrame sorted in chronological order.
+    entries:
+        Boolean Series with entry signals aligned to ``df``.
+    tp_pct:
+        Target take-profit percentage expressed as a decimal (e.g. ``0.05`` for 5%).
+    name:
+        Strategy name used for output files.
+    """
+
+    if tp_pct <= 0:
+        raise ValueError("tp_pct must be positive")
+
+    _validate_dataframe(df, REQUIRED_COLUMNS)
+    entries = _ensure_boolean_series(entries, df.index)
+
+    open_prices = df["Open"].astype(float)
+    high_prices = df["High"].astype(float)
+    close_prices = df["Close"].astype(float)
+
+    trade_records: List[dict] = []
+
+    for idx, signal in enumerate(entries[:-1]):
+        if not signal:
+            continue
+
+        entry_idx = idx + 1
+        entry_date = df.index[entry_idx]
+        entry_price = float(open_prices.iat[entry_idx])
+
+        if entry_price <= 0:
+            continue
+
+        shares = int(TRADE_CAPITAL // entry_price)
+        if shares <= 0:
+            continue
+
+        target_price = entry_price * (1 + tp_pct)
+
+        exit_idx = None
+        hit_target = False
+        for search_idx in range(entry_idx, len(df)):
+            if high_prices.iat[search_idx] >= target_price:
+                exit_idx = search_idx
+                hit_target = True
+                break
+
+        if exit_idx is None:
+            exit_idx = len(df) - 1
+
+        exit_date = df.index[exit_idx]
+        exit_price = target_price if hit_target else float(close_prices.iat[exit_idx])
+
+        entry_value = entry_price * shares
+        exit_value = exit_price * shares
+
+        entry_fee = _calculate_fee(entry_value)
+        exit_fee = _calculate_fee(exit_value)
+        total_fees = entry_fee + exit_fee
+
+        gross_pnl = (exit_price - entry_price) * shares
+        net_pnl = gross_pnl - total_fees
+        capital_used = entry_price * shares if entry_price > 0 else TRADE_CAPITAL
+        return_pct = net_pnl / capital_used if capital_used else 0.0
+
+        trade_records.append(
+            {
+                "EntryDate": entry_date,
+                "SignalDate": df.index[idx],
+                "EntryPrice": entry_price,
+                "Shares": shares,
+                "TargetPrice": target_price,
+                "ExitDate": exit_date,
+                "ExitPrice": exit_price,
+                "HitTarget": hit_target,
+                "EntryFee": entry_fee,
+                "ExitFee": exit_fee,
+                "TotalFees": total_fees,
+                "GrossPnL": gross_pnl,
+                "NetPnL": net_pnl,
+                "ReturnPct": return_pct,
+            }
+        )
+
+    trades_df = pd.DataFrame(trade_records)
+
+    if not trades_df.empty:
+        hit_rate = trades_df["HitTarget"].mean()
+        total_pnl = trades_df["NetPnL"].sum()
+        cumulative_return = trades_df["NetPnL"].sum() / (TRADE_CAPITAL * len(trades_df))
+    else:
+        hit_rate = 0.0
+        total_pnl = 0.0
+        cumulative_return = 0.0
+
+    summary = {
+        "Strategy": name,
+        "Trades": int(len(trades_df)),
+        "HitRate": float(hit_rate),
+        "TotalPnL": float(total_pnl),
+        "CumReturn": float(cumulative_return),
+    }
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    sanitized_name = _sanitize_name(name)
+    csv_path = DATA_DIR / f"{sanitized_name}_trades.csv"
+    trades_df.to_csv(csv_path, index=False)
+
+    return trades_df, summary
+
+
+__all__ = ["run_tp_backtest"]

--- a/strategies.py
+++ b/strategies.py
@@ -1,0 +1,135 @@
+"""Trading strategy signal generators.
+
+This module provides several signal-generating functions that operate on
+price/volume DataFrames. Each function returns a boolean ``Series`` aligned
+with the input DataFrame index, indicating entry opportunities for the
+respective strategy.
+
+All functions validate the required columns and handle missing values by
+forward-filling rolling calculations. Missing price/volume data will result in
+``False`` signals for those rows.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+
+
+REQUIRED_COLUMNS = {"Open", "High", "Low", "Close", "Volume"}
+
+
+def _validate_dataframe(df: pd.DataFrame, required: Iterable[str]) -> None:
+    """Ensure the DataFrame contains the required columns.
+
+    Parameters
+    ----------
+    df:
+        Input OHLCV DataFrame.
+    required:
+        Iterable of required column names.
+
+    Raises
+    ------
+    ValueError
+        If any required column is missing.
+    """
+
+    missing = [column for column in required if column not in df.columns]
+    if missing:
+        raise ValueError(
+            "DataFrame is missing required columns: " + ", ".join(sorted(missing))
+        )
+
+
+def _safe_rolling_mean(series: pd.Series, window: int) -> pd.Series:
+    """Return a simple moving average while preserving the Series index."""
+
+    return series.rolling(window=window, min_periods=window).mean()
+
+
+def _compute_rsi(series: pd.Series, period: int = 14) -> pd.Series:
+    """Compute the Relative Strength Index (RSI).
+
+    The implementation uses the classic Wilder smoothing method.
+    """
+
+    delta = series.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+
+    avg_gain = gain.ewm(alpha=1 / period, adjust=False, min_periods=period).mean()
+    avg_loss = loss.ewm(alpha=1 / period, adjust=False, min_periods=period).mean()
+
+    rs = avg_gain / avg_loss
+    rsi = 100 - (100 / (1 + rs))
+    return rsi.fillna(0)
+
+
+def sma_cross(df: pd.DataFrame) -> pd.Series:
+    """Return entry signals where the 10-period SMA crosses above the 50-period SMA."""
+
+    _validate_dataframe(df, REQUIRED_COLUMNS)
+    close = df["Close"].astype(float)
+
+    sma_fast = _safe_rolling_mean(close, 10)
+    sma_slow = _safe_rolling_mean(close, 50)
+
+    cross_up = (sma_fast > sma_slow) & (sma_fast.shift(1) <= sma_slow.shift(1))
+    cross_up = cross_up & sma_fast.notna() & sma_slow.notna()
+    return cross_up.fillna(False)
+
+
+def pullback_uptrend(df: pd.DataFrame) -> pd.Series:
+    """Return entry signals for pullbacks within an uptrend.
+
+    A signal is generated when the close is above the 50-period SMA and the
+    14-period RSI is below 40 (oversold in an uptrend scenario).
+    """
+
+    _validate_dataframe(df, REQUIRED_COLUMNS)
+    close = df["Close"].astype(float)
+
+    sma_50 = _safe_rolling_mean(close, 50)
+    rsi_14 = _compute_rsi(close, 14)
+
+    signal = (close > sma_50) & (rsi_14 < 40)
+    return signal.fillna(False)
+
+
+def donchian_breakout(df: pd.DataFrame) -> pd.Series:
+    """Return entry signals when price breaks above the prior 20-day high."""
+
+    _validate_dataframe(df, REQUIRED_COLUMNS)
+    high = df["High"].astype(float)
+    close = df["Close"].astype(float)
+
+    prior_high = high.rolling(window=20, min_periods=20).max().shift(1)
+    signal = close > prior_high
+    return signal.fillna(False)
+
+
+def gapup_highvol(df: pd.DataFrame) -> pd.Series:
+    """Return entry signals for gap-up openings with elevated volume."""
+
+    _validate_dataframe(df, REQUIRED_COLUMNS)
+    open_ = df["Open"].astype(float)
+    high = df["High"].astype(float)
+    volume = df["Volume"].astype(float)
+
+    prev_high = high.shift(1)
+    prev_volume = volume.shift(1)
+
+    gap_condition = open_ > (prev_high * 1.01)
+    volume_condition = volume > (prev_volume * 1.5)
+
+    signal = gap_condition & volume_condition
+    return signal.fillna(False)
+
+
+__all__ = [
+    "sma_cross",
+    "pullback_uptrend",
+    "donchian_breakout",
+    "gapup_highvol",
+]


### PR DESCRIPTION
## Summary
- add trading strategy signal generators for SMA crossovers, pullbacks, breakouts, and gap-up setups
- implement a take-profit backtester with brokerage fee modeling and CSV export

## Testing
- python -m compileall strategies.py backtester.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d94196dc833096496b5ab4ac45b3