### PR TITLE
Add Flask dashboard for strategy monitoring

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,299 @@
+"""ASX Strategies dashboard application."""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import uuid
+from datetime import datetime, date
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import plotly.graph_objects as go
+from flask import Flask, abort, flash, render_template
+
+APP_ROOT = Path(__file__).resolve().parent
+DATA_DIR = APP_ROOT / "data"
+DEFAULT_DB_PATH = APP_ROOT / "signals.db"
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def configure_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", "asx-dashboard-secret")
+    app.config["DATA_DIRECTORY"] = DATA_DIR
+    app.config["DB_PATH"] = Path(os.environ.get("SIGNALS_DB_PATH", str(DEFAULT_DB_PATH)))
+    return app
+
+
+app = configure_app()
+
+
+@app.context_processor
+def inject_last_refreshed() -> Dict[str, str]:
+    return {"last_refreshed": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+
+
+def humanise_number(value: Any) -> str:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return "—"
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if abs(number) >= 1_000_000:
+        return f"{number/1_000_000:.2f}M"
+    if abs(number) >= 1_000:
+        return f"{number/1_000:.2f}K"
+    if abs(number) >= 1:
+        return f"{number:.2f}"
+    return f"{number:.4f}"
+
+
+def determine_time_column(df: pd.DataFrame) -> Optional[str]:
+    time_candidates = ["date", "timestamp", "datetime", "time", "as_of", "created_at"]
+    for candidate in time_candidates:
+        for column in df.columns:
+            if column.lower() == candidate:
+                converted = pd.to_datetime(df[column], errors="coerce")
+                if converted.notna().any():
+                    df[column] = converted
+                    return column
+    return None
+
+
+def build_plotly_config(df: pd.DataFrame, title: str) -> Optional[Dict[str, Any]]:
+    if df.empty:
+        return None
+    numeric_df = df.select_dtypes(include="number")
+    if numeric_df.empty:
+        return None
+
+    x_col = determine_time_column(df)
+    if x_col:
+        x_values = df[x_col].astype(str).tolist()
+    else:
+        x_values = list(range(1, len(df) + 1))
+
+    fig = go.Figure()
+    max_series = 5
+    for col in numeric_df.columns[:max_series]:
+        fig.add_trace(
+            go.Scatter(
+                x=x_values,
+                y=numeric_df[col],
+                mode="lines+markers",
+                name=col,
+                hovertemplate="%{y:.4f}<extra>{}</extra>".format(col),
+            )
+        )
+
+    fig.update_layout(
+        title=title,
+        template="plotly_white",
+        margin=dict(l=30, r=10, t=50, b=30),
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    )
+    return fig.to_dict()
+
+
+def read_csv_file(file_path: Path) -> Optional[pd.DataFrame]:
+    try:
+        df = pd.read_csv(file_path)
+    except FileNotFoundError:
+        logger.warning("CSV file not found: %s", file_path)
+        return None
+    except pd.errors.EmptyDataError:
+        logger.warning("CSV file is empty: %s", file_path)
+        return pd.DataFrame()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.error("Unable to read CSV %s: %s", file_path, exc)
+        return None
+
+    for column in df.columns:
+        if df[column].dtype == object:
+            parsed = pd.to_datetime(df[column], errors="coerce")
+            if parsed.notna().any():
+                df[column] = parsed
+    return df
+
+
+def snapshot_numeric_metrics(df: pd.DataFrame) -> Dict[str, str]:
+    metrics: Dict[str, str] = {}
+    if df.empty:
+        return metrics
+
+    metric_candidates = {
+        "Total Return": ["total_return", "return", "returns"],
+        "PnL": ["pnl", "pl", "profit", "net_profit"],
+        "Win Rate": ["win_rate", "winrate"],
+        "Sharpe": ["sharpe", "sharpe_ratio"],
+        "Trades": ["trade_count", "trades", "num_trades"],
+    }
+
+    lower_columns = {col.lower(): col for col in df.columns}
+    for label, aliases in metric_candidates.items():
+        for alias in aliases:
+            if alias in lower_columns:
+                source_col = lower_columns[alias]
+                value = df[source_col].iloc[-1]
+                if pd.api.types.is_numeric_dtype(df[source_col]):
+                    metrics[label] = humanise_number(value)
+                else:
+                    metrics[label] = str(value)
+                break
+
+    if "Trades" not in metrics:
+        metrics["Trades"] = str(len(df))
+    return metrics
+
+
+def load_strategy_summaries(data_dir: Path) -> List[Dict[str, Any]]:
+    if not data_dir.exists():
+        logger.info("Data directory does not exist: %s", data_dir)
+        return []
+
+    summaries: List[Dict[str, Any]] = []
+    for csv_path in sorted(data_dir.glob("*.csv")):
+        df = read_csv_file(csv_path)
+        if df is None:
+            continue
+        display_name = csv_path.stem.replace("_", " ").title()
+        table_df = df.copy()
+        table_html = table_df.to_html(
+            classes="table table-hover table-sm align-middle",
+            index=False,
+            border=0,
+            max_rows=50,
+            justify="center",
+        )
+        summary = {
+            "display_name": display_name,
+            "source": csv_path,
+            "table_html": table_html,
+            "numeric_snapshot": snapshot_numeric_metrics(df),
+            "chart_id": f"chart-{uuid.uuid4().hex}",
+            "chart_json": build_plotly_config(df, f"{display_name} Metrics"),
+        }
+        summaries.append(summary)
+    return summaries
+
+
+def read_database(db_path: Path) -> Optional[pd.DataFrame]:
+    if not db_path.exists():
+        logger.warning("Signals database not found at %s", db_path)
+        return None
+    try:
+        with sqlite3.connect(db_path) as connection:
+            connection.row_factory = sqlite3.Row
+            cursor = connection.cursor()
+            tables = cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            ).fetchall()
+            if not tables:
+                logger.warning("No tables found in database %s", db_path)
+                return pd.DataFrame()
+            table_name = "alerts"
+            if (table_name,) not in tables:
+                table_name = tables[0][0]
+            rows = cursor.execute(f"SELECT * FROM {table_name}").fetchall()
+    except sqlite3.Error as exc:
+        logger.error("Database error reading %s: %s", db_path, exc)
+        return None
+
+    if not rows:
+        return pd.DataFrame()
+    df = pd.DataFrame(rows, columns=rows[0].keys())
+    return df
+
+
+def filter_signals_for_today(df: pd.DataFrame, target_date: date) -> pd.DataFrame:
+    if df.empty:
+        return df
+    filtered = df.copy()
+    date_columns = []
+    for column in df.columns:
+        converted = pd.to_datetime(df[column], errors="coerce")
+        if converted.notna().any():
+            mask = converted.dt.date == target_date
+            if mask.any():
+                filtered = df.loc[mask]
+                filtered[column] = converted.loc[mask]
+                date_columns.append(column)
+                break
+    if filtered.empty:
+        return df.head(0)
+    for column in date_columns:
+        filtered[column] = pd.to_datetime(filtered[column], errors="coerce")
+    filtered = filtered.sort_values(by=date_columns or filtered.columns.tolist())
+    filtered.reset_index(drop=True, inplace=True)
+    return filtered
+
+
+def locate_trade_file(ticker: str, data_dir: Path) -> Optional[Path]:
+    candidates = [
+        data_dir / f"{ticker}.csv",
+        data_dir / f"{ticker.lower()}.csv",
+        data_dir / f"trades_{ticker}.csv",
+        data_dir / f"trades_{ticker.lower()}.csv",
+        data_dir / "trades" / f"{ticker}.csv",
+        data_dir / "trades" / f"{ticker.lower()}.csv",
+        data_dir / "trades" / f"trades_{ticker}.csv",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    matches = list(data_dir.glob(f"**/*{ticker}*.csv"))
+    return matches[0] if matches else None
+
+
+@app.route("/")
+def index():
+    summaries = load_strategy_summaries(app.config["DATA_DIRECTORY"])
+    chart_configs = [
+        {"id": summary["chart_id"], "config": summary["chart_json"]} for summary in summaries
+    ]
+    return render_template(
+        "index.html",
+        summaries=summaries,
+        chart_configs=chart_configs,
+        data_directory=app.config["DATA_DIRECTORY"],
+    )
+
+
+@app.route("/signals")
+def signals():
+    df = read_database(app.config["DB_PATH"])
+    if df is None:
+        flash("Signals database could not be read. Please verify the connection.")
+        df = pd.DataFrame()
+    today = datetime.now().date()
+    today_signals = filter_signals_for_today(df, today)
+    return render_template("signals.html", signals_df=today_signals)
+
+
+@app.route("/trades/<string:ticker>")
+def trades(ticker: str):
+    ticker = ticker.upper()
+    file_path = locate_trade_file(ticker, app.config["DATA_DIRECTORY"])
+    if not file_path:
+        abort(404, description=f"No trade history found for ticker {ticker}.")
+
+    df = read_csv_file(file_path)
+    if df is None:
+        abort(500, description="Unable to read trade data.")
+
+    chart_config = build_plotly_config(df, f"{ticker} Trades")
+    return render_template(
+        "trades.html",
+        ticker=ticker,
+        trades_df=df,
+        chart_config=chart_config,
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)), debug=False)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,63 @@
+{% extends "layout.html" %}
+{% block title %}Strategy Summary - ASX Strategies Dashboard{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h3 mb-1">Strategy Performance Overview</h1>
+        <p class="text-muted mb-0">Aggregated view of strategies sourced from CSV summaries.</p>
+    </div>
+    <a class="btn btn-outline-primary" href="{{ url_for('signals') }}">View Signals</a>
+</div>
+{% if summaries %}
+    <div class="row gy-4">
+        {% for summary in summaries %}
+            <div class="col-12 col-lg-6">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start mb-3">
+                            <div>
+                                <h2 class="h5 mb-0">{{ summary.display_name }}</h2>
+                                <small class="text-muted">Source: {{ summary.source.name }}</small>
+                            </div>
+                            {% if summary.numeric_snapshot %}
+                                <div class="text-end">
+                                    {% for label, value in summary.numeric_snapshot.items() %}
+                                        <div class="small text-muted">{{ label }}: <span class="fw-semibold">{{ value }}</span></div>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        <div class="table-responsive mb-3">
+                            {{ summary.table_html | safe }}
+                        </div>
+                        {% if summary.chart_json %}
+                            <div id="{{ summary.chart_id }}" style="height:320px;"></div>
+                        {% else %}
+                            <div class="alert alert-info small" role="alert">
+                                No numeric data available for charting.
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% else %}
+    <div class="alert alert-warning" role="alert">
+        No CSV summaries were found in {{ data_directory }}.
+    </div>
+{% endif %}
+{% endblock %}
+{% block body_scripts %}
+{{ super() }}
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const chartConfigs = {{ chart_configs | tojson | safe }};
+        chartConfigs.forEach(({id, config}) => {
+            if (config && document.getElementById(id)) {
+                Plotly.newPlot(id, config.data, config.layout, {responsive: true, displayModeBar: false});
+            }
+        });
+    });
+</script>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="refresh" content="60">
+    <title>{% block title %}ASX Strategies Dashboard{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-TNMGnD65V6pGPLtfRVPC5zsxFrqxbPjzjuY4xXHzkwmo7aX6ixkmKsgNHfYkP82" crossorigin="anonymous">
+    <style>
+        body {
+            background-color: #f7f9fc;
+        }
+        .navbar-brand {
+            font-weight: 600;
+            letter-spacing: 0.05rem;
+        }
+        .card {
+            border: none;
+            box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.08);
+        }
+        table th {
+            white-space: nowrap;
+        }
+        .table-responsive {
+            max-height: 65vh;
+        }
+        footer {
+            font-size: 0.875rem;
+            color: #6c757d;
+        }
+    </style>
+    {% block head_scripts %}{% endblock %}
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light border-bottom mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">ASX Strategies</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">Summary</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('signals') }}">Signals</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<main class="container mb-5">
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="alert alert-warning" role="alert">
+                {% for message in messages %}
+                    <div>{{ message }}</div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</main>
+<footer class="text-center py-4">
+    Updated {{ last_refreshed|default('n/a') }}
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-y6ogn5Ge0XEt3G5UpiRaY1oCbcnZ6+QcmGeXjr6UIK/Y/xFdVtOfvtTDHkJNNZ4c" crossorigin="anonymous"></script>
+<script src="https://cdn.plot.ly/plotly-2.26.0.min.js" defer></script>
+{% block body_scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/signals.html
+++ b/templates/signals.html
@@ -1,0 +1,24 @@
+{% extends "layout.html" %}
+{% block title %}Signals - ASX Strategies Dashboard{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h3 mb-1">Today's Signals</h1>
+        <p class="text-muted mb-0">Pulled directly from the alerts database.</p>
+    </div>
+    <a class="btn btn-outline-secondary" href="{{ url_for('index') }}">Back to Summary</a>
+</div>
+<div class="card">
+    <div class="card-body">
+        {% if not signals_df.empty %}
+            <div class="table-responsive">
+                {{ signals_df.to_html(classes="table table-striped table-sm align-middle", index=False) | safe }}
+            </div>
+        {% else %}
+            <div class="alert alert-info mb-0" role="alert">
+                No alerts were found for today.
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/trades.html
+++ b/templates/trades.html
@@ -1,0 +1,45 @@
+{% extends "layout.html" %}
+{% block title %}{{ ticker }} Trades - ASX Strategies Dashboard{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h3 mb-1">{{ ticker }} Trade History</h1>
+        <p class="text-muted mb-0">Historical executions sourced from CSV files.</p>
+    </div>
+    <div class="d-flex gap-2">
+        <a class="btn btn-outline-secondary" href="{{ url_for('index') }}">Back to Summary</a>
+        <a class="btn btn-outline-primary" href="{{ url_for('signals') }}">View Signals</a>
+    </div>
+</div>
+<div class="card mb-4">
+    <div class="card-body">
+        {% if not trades_df.empty %}
+            <div class="table-responsive mb-3">
+                {{ trades_df.to_html(classes="table table-striped table-sm align-middle", index=False) | safe }}
+            </div>
+            {% if chart_config %}
+                <div id="trades-chart" style="height:360px;"></div>
+            {% else %}
+                <div class="alert alert-info mb-0" role="alert">
+                    No numeric columns available to visualise.
+                </div>
+            {% endif %}
+        {% else %}
+            <div class="alert alert-warning mb-0" role="alert">
+                No trades were found for ticker {{ ticker }}.
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}
+{% block body_scripts %}
+{{ super() }}
+{% if chart_config %}
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const config = {{ chart_config | tojson | safe }};
+        Plotly.newPlot('trades-chart', config.data, config.layout, {responsive: true, displayModeBar: false});
+    });
+</script>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a Flask-based dashboard that loads strategy summaries, signals, and trades from CSV files and SQLite
- add Bootstrap-styled templates with auto-refresh, charts, and responsive layouts for summary, signals, and trade pages
- provide resilient data loading with Plotly visualisation and graceful fallbacks when sources are missing

## Testing
- python -m py_compile dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d94c646083308014fa4c296a600a