### PR TITLE
Fix Plotly hovertemplate formatting to preserve y placeholder

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -87,7 +87,7 @@ def build_plotly_config(df: pd.DataFrame, title: str) -> Optional[Dict[str, Any]
                 y=numeric_df[col],
                 mode="lines+markers",
                 name=col,
-                hovertemplate="%{y:.4f}<extra>{}</extra>".format(col),
+                hovertemplate=f"%{{y:.4f}}<extra>{col}</extra>",
             )
         )
 


### PR DESCRIPTION
## Summary
- update the dashboard Plotly hovertemplate to use an f-string so the %{y} placeholder is preserved

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68e0e183d49c83308a724bab939c9002