### PR TITLE
Handle duplicate OHLCV columns during normalization

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -66,6 +66,25 @@ def test_data_fetcher_handles_multi_index_columns(monkeypatch: pytest.MonkeyPatc
     assert not saved.empty
 
 
+def test_normalize_price_dataframe_consolidates_close_columns() -> None:
+    frame = pd.DataFrame(
+        {
+            "Date": ["2024-01-01", "2024-01-02"],
+            "Open": [10.0, 11.0],
+            "High": [10.5, 11.5],
+            "Low": [9.5, 10.5],
+            "Close": [10.25, float("nan")],
+            "Adj Close": [10.2, 11.1],
+            "Volume": [1_000_000, 1_010_000],
+        }
+    )
+
+    normalized = data_fetcher.normalize_price_dataframe(frame)
+
+    assert list(normalized.columns) == data_fetcher.EXPECTED_COLUMNS
+    assert normalized["Close"].tolist() == [10.25, 11.1]
+
+
 def test_strategies_produce_boolean_series() -> None:
     frame = _sample_ohlcv(60).set_index("Date")
     for strategy in (


### PR DESCRIPTION
## Summary
- consolidate duplicate OHLCV columns in normalize_price_dataframe by preferring the first non-null value
- drop redundant duplicate columns before final column selection and coercion
- add an integration test ensuring close data is preserved when both Close and Adj Close are present

## Testing
- `PYTHONPATH=. pytest tests/test_integration.py::test_normalize_price_dataframe_consolidates_close_columns`
- `PYTHONPATH=. pytest` *(fails: existing config.json is invalid JSON and dashboard route test expects registered routes)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fa9dbc5c8330b88474f6dfb203a5