### PR TITLE
Expose alerts database helper and verify signals route renders data

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,4 +2,4 @@
    "tickers": ["PTM.AX", "RMS.AX", "CMW.AX", "DYL.AX", "REG.AX", "MSB.AX", "LOT.AX", "EVT.AX", "SLX.AX", "NWH.AX", "RED.AX", "IMD.AX", "ABB.AX", "ELD.AX", "MMS.AX", "WPR.AX", "ARF.AX", "SGM.AX", "DBI.AX", "WEB.AX"],
 
   "start_date": "2000-01-01"
-
+}

--- a/dashboard.py
+++ b/dashboard.py
@@ -13,6 +13,8 @@ import pandas as pd
 import plotly.graph_objects as go
 from flask import Flask, flash, render_template, url_for
 
+from alerts import ensure_alerts_database
+
 APP_ROOT = Path(__file__).resolve().parent
 DATA_DIR = APP_ROOT / "data"
 DEFAULT_DB_PATH = APP_ROOT / "db" / "signals.db"
@@ -349,7 +351,8 @@ def load_strategy_summaries(data_dir: Path) -> List[Dict[str, Any]]:
 
 def read_database(db_path: Path) -> Optional[pd.DataFrame]:
     try:
-        ensure_signals_database(db_path)
+        with ensure_alerts_database(db_path):
+            pass
     except Exception:
         logger.error("Signals database could not be ensured at %s", db_path)
         return None


### PR DESCRIPTION
## Summary
- expose a public `ensure_alerts_database` helper in `alerts.py` and use it when persisting or initialising the alerts schema
- import the helper into `dashboard.py` so `read_database` initialises the SQLite schema before querying
- extend the dashboard integration test to seed alerts via the public helper, assert the rendered signals table, and repair the sample config JSON

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0ff5b6b6c8330b445b98bc8f070bb