### PR TITLE
Refine dashboard UI and chart handling

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,56 @@
+const initialiseCharts = () => {
+    if (typeof Plotly === 'undefined') {
+        return;
+    }
+
+    const chartsToRender = [];
+
+    const multiChartScript = document.getElementById('chart-configs-data');
+    if (multiChartScript) {
+        try {
+            const payload = JSON.parse(multiChartScript.textContent || '[]');
+            payload.forEach((entry) => {
+                if (!entry || !entry.id || !entry.config) {
+                    return;
+                }
+                const target = document.getElementById(entry.id);
+                if (!target) {
+                    return;
+                }
+                chartsToRender.push({ element: target, config: entry.config });
+            });
+        } catch (error) {
+            console.error('Unable to parse chart configuration payload', error);
+        }
+    }
+
+    const singleChartScript = document.getElementById('single-chart-config');
+    if (singleChartScript) {
+        try {
+            const chartConfig = JSON.parse(singleChartScript.textContent || '{}');
+            const target = document.getElementById('trades-chart');
+            if (target && chartConfig && chartConfig.data && chartConfig.layout) {
+                chartsToRender.push({ element: target, config: chartConfig });
+            }
+        } catch (error) {
+            console.error('Unable to parse single chart configuration', error);
+        }
+    }
+
+    chartsToRender.forEach(({ element, config }) => {
+        const layout = { ...(config.layout || {}), autosize: true };
+        const chart = Plotly.newPlot(
+            element,
+            config.data || [],
+            layout,
+            { responsive: true, displayModeBar: false }
+        );
+        if (chart) {
+            window.addEventListener('resize', () => {
+                Plotly.Plots.resize(element);
+            });
+        }
+    });
+};
+
+document.addEventListener('DOMContentLoaded', initialiseCharts);

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,30 @@
 {% extends "layout.html" %}
 {% block title %}Strategy Summary - ASX Strategies Dashboard{% endblock %}
 {% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
     <div>
         <h1 class="h3 mb-1">Strategy Performance Overview</h1>
         <p class="text-muted mb-0">Aggregated view of strategies sourced from CSV summaries.</p>
     </div>
     <a class="btn btn-outline-primary" href="{{ url_for('signals') }}">View Signals</a>
 </div>
+{% if summary_cards %}
+    <div class="row g-3 mb-4">
+        {% for card in summary_cards %}
+            <div class="col-12 col-sm-6 col-xl-3">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-body">
+                        <p class="text-muted text-uppercase small mb-1">{{ card.label }}</p>
+                        <h2 class="h4 mb-2">{{ card.value }}</h2>
+                        {% if card.description %}
+                            <p class="text-muted small mb-0">{{ card.description }}</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endif %}
 {% if equity_curve_chart or trades_chart %}
     <div class="row gy-4 mb-4">
         {% if equity_curve_chart %}
@@ -57,9 +74,36 @@
                                 </div>
                             {% endif %}
                         </div>
-                        <div class="table-responsive mb-3">
-                            {{ summary.table_html | safe }}
-                        </div>
+                        {% if summary.table_columns %}
+                            <div class="table-responsive mb-3">
+                                <table class="table table-striped table-hover table-sm align-middle mb-0">
+                                    <thead class="table-light">
+                                        <tr>
+                                            {% for column in summary.table_columns %}
+                                                <th scope="col">{{ column }}</th>
+                                            {% endfor %}
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for row in summary.table_rows %}
+                                            <tr>
+                                                {% for cell in row %}
+                                                    <td>{{ cell if cell is not none else "—" }}</td>
+                                                {% endfor %}
+                                            </tr>
+                                        {% else %}
+                                            <tr>
+                                                <td class="text-center text-muted" colspan="{{ summary.table_columns|length }}">No rows to display.</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                            <div class="alert alert-info" role="alert">
+                                No tabular data available for this strategy.
+                            </div>
+                        {% endif %}
                         {% if summary.chart_json %}
                             <div id="{{ summary.chart_id }}" style="height:320px;"></div>
                         {% else %}
@@ -74,20 +118,23 @@
     </div>
 {% else %}
     <div class="alert alert-warning" role="alert">
-        No CSV summaries were found in {{ data_directory }}.
+        <div class="d-flex flex-column flex-lg-row justify-content-between gap-2">
+            <div>
+                <h2 class="h5 mb-1">No strategy summaries available</h2>
+                <p class="mb-0">We could not find any CSV summaries in <code>{{ data_directory }}</code>.</p>
+            </div>
+            <div class="d-flex flex-column flex-sm-row gap-2 align-items-start align-items-sm-center">
+                <a class="alert-link" href="{{ url_for('index') }}?action=run_daily_job">Run daily job</a>
+                <span class="text-muted d-none d-sm-inline">|</span>
+                <a class="alert-link" href="{{ url_for('signals') }}">Review today's signals</a>
+            </div>
+        </div>
     </div>
 {% endif %}
 {% endblock %}
 {% block body_scripts %}
 {{ super() }}
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const chartConfigs = {{ chart_configs | tojson | safe }};
-        chartConfigs.forEach(({id, config}) => {
-            if (config && document.getElementById(id)) {
-                Plotly.newPlot(id, config.data, config.layout, {responsive: true, displayModeBar: false});
-            }
-        });
-    });
-</script>
+{% if chart_configs %}
+<script type="application/json" id="chart-configs-data">{{ chart_configs | tojson | safe }}</script>
+{% endif %}
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -78,6 +78,7 @@
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-y6ogn5Ge0XEt3G5UpiRaY1oCbcnZ6+QcmGeXjr6UIK/Y/xFdVtOfvtTDHkJNNZ4c" crossorigin="anonymous"></script>
 <script src="https://cdn.plot.ly/plotly-2.26.0.min.js" defer></script>
+<script src="{{ url_for('static', filename='js/dashboard.js') }}" defer></script>
 {% block body_scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/signals.html
+++ b/templates/signals.html
@@ -10,13 +10,40 @@
 </div>
 <div class="card">
     <div class="card-body">
-        {% if not signals_df.empty %}
+        {% if has_signals and table_columns %}
             <div class="table-responsive">
-                {{ signals_df.to_html(classes="table table-striped table-sm align-middle", index=False) | safe }}
+                <table class="table table-striped table-sm align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            {% for column in table_columns %}
+                                <th scope="col">{{ column }}</th>
+                            {% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in table_rows %}
+                            <tr>
+                                {% for cell in row %}
+                                    <td>{{ cell if cell is not none else "—" }}</td>
+                                {% endfor %}
+                            </tr>
+                        {% else %}
+                            <tr>
+                                <td class="text-center text-muted" colspan="{{ table_columns|length }}">No rows to display.</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         {% else %}
             <div class="alert alert-info mb-0" role="alert">
-                No alerts were found for today.
+                <div class="d-flex flex-column flex-md-row justify-content-between gap-2">
+                    <div>
+                        <strong>No alerts were found for today.</strong>
+                        <div class="small">Signals will appear here after the daily job imports data from {{ database_path }}.</div>
+                    </div>
+                    <a class="alert-link" href="{{ url_for('index') }}?action=run_daily_job">Run daily job</a>
+                </div>
             </div>
         {% endif %}
     </div>

--- a/templates/trades.html
+++ b/templates/trades.html
@@ -13,9 +13,30 @@
 </div>
 <div class="card mb-4">
     <div class="card-body">
-        {% if not trades_df.empty %}
+        {% if table_columns %}
             <div class="table-responsive mb-3">
-                {{ trades_df.to_html(classes="table table-striped table-hover table-sm align-middle", index=False) | safe }}
+                <table class="table table-striped table-hover table-sm align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            {% for column in table_columns %}
+                                <th scope="col">{{ column }}</th>
+                            {% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in table_rows %}
+                            <tr>
+                                {% for cell in row %}
+                                    <td>{{ cell if cell is not none else "—" }}</td>
+                                {% endfor %}
+                            </tr>
+                        {% else %}
+                            <tr>
+                                <td class="text-center text-muted" colspan="{{ table_columns|length }}">No rows to display.</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
             {% if chart_config %}
                 <div id="trades-chart" style="height:360px;"></div>
@@ -26,7 +47,13 @@
             {% endif %}
         {% elif not_found %}
             <div class="alert alert-warning mb-0" role="alert">
-                No trade history is available for {{ ticker }}. Please upload a CSV to {{ data_source or 'the data directory' }}.
+                <div class="d-flex flex-column flex-md-row justify-content-between gap-2">
+                    <div>
+                        <strong>No trade history is available for {{ ticker }}.</strong>
+                        <div class="small">Upload a CSV to {{ data_source or 'the data directory' }} to populate this table.</div>
+                    </div>
+                    <a class="alert-link" href="{{ url_for('index') }}?action=run_daily_job">Run daily job</a>
+                </div>
             </div>
         {% else %}
             <div class="alert alert-info mb-0" role="alert">
@@ -39,11 +66,6 @@
 {% block body_scripts %}
 {{ super() }}
 {% if chart_config %}
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const config = {{ chart_config | tojson | safe }};
-        Plotly.newPlot('trades-chart', config.data, config.layout, {responsive: true, displayModeBar: false});
-    });
-</script>
+<script type="application/json" id="single-chart-config">{{ chart_config | tojson | safe }}</script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace pandas-generated HTML tables with Jinja-rendered Bootstrap tables and add strategy metric cards
- extract chart rendering into a reusable static script and enable responsive Plotly embeds across pages
- improve error handling in the dashboard views with actionable alerts when data files are missing

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'alerts')*

------
https://chatgpt.com/codex/tasks/task_e_68e10e8735ec83308e635df19f06bf87