### PR TITLE
Fix module imports for tests and clean dashboard chart init

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends 'layout.html' %}
 {% block title %}Strategy Summary - ASX Strategies Dashboard{% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -83,9 +83,9 @@
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         const chartConfigs = {{ chart_configs | tojson | safe }};
-        chartConfigs.forEach(({id, config}) => {
+        chartConfigs.forEach(({ id, config }) => {
             if (config && document.getElementById(id)) {
-                Plotly.newPlot(id, config.data, config.layout, {responsive: true, displayModeBar: false});
+                Plotly.newPlot(id, config.data, config.layout, { responsive: true, displayModeBar: false });
             }
         });
     });

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for ensuring project modules are importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- ensure pytest can import project modules by adding a `tests/conftest.py` that injects the repository root onto `sys.path`
- tidy the dashboard index template so chart initialisation uses consistent spacing and inherits the base layout as expected

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e187880c948330bc875a69023c9cc7