### PR TITLE
Handle default take profit and stop loss configuration

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import alerts
@@ -7,7 +8,7 @@ import data_fetcher
 import run_daily
 
 
-def test_full_pipeline(monkeypatch, config_path, sample_price_data, tmp_path, mock_data_fetch):
+def _prepare_pipeline_environment(monkeypatch, tmp_path):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     reports_dir = tmp_path / "reports"
@@ -33,7 +34,29 @@ def test_full_pipeline(monkeypatch, config_path, sample_price_data, tmp_path, mo
     monkeypatch.setattr(run_daily.Backtester, "__init__", fake_backtester_init, raising=False)
     monkeypatch.setattr(alerts.AlertsManager, "__init__", fake_alerts_init, raising=False)
 
+    return reports_dir
+
+
+def test_full_pipeline(monkeypatch, config_path, sample_price_data, tmp_path, mock_data_fetch):
+    reports_dir = _prepare_pipeline_environment(monkeypatch, tmp_path)
+
     stats = run_daily.orchestrate(str(config_path))
+    assert stats["fetched"] == 1
+    assert stats["strategies"] == 4
+    assert stats["alerts"] >= 0
+    assert (reports_dir / "strategy_summary.csv").exists() or stats["trades"] == 0
+
+
+def test_pipeline_defaults(monkeypatch, config_path, sample_price_data, tmp_path, mock_data_fetch):
+    reports_dir = _prepare_pipeline_environment(monkeypatch, tmp_path)
+
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    cfg.pop("take_profit_pct")
+    cfg.pop("stop_loss_pct")
+    missing_config = tmp_path / "config_missing.json"
+    missing_config.write_text(json.dumps(cfg), encoding="utf-8")
+
+    stats = run_daily.orchestrate(str(missing_config))
     assert stats["fetched"] == 1
     assert stats["strategies"] == 4
     assert stats["alerts"] >= 0


### PR DESCRIPTION
## Summary
- add module-level defaults for take-profit and stop-loss percentages and validate configuration values
- update orchestrate to log when defaults are used and reject non-positive overrides
- extend integration coverage to ensure the pipeline runs when thresholds are omitted

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e190f65dbc8330bb9c8466913cfe55